### PR TITLE
Fix 10 stock bug

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,1 @@
-VITE_API_URL=http://localhost:1234/v1
-VITE_API_AUTH_TOKEN=your_jwt_token_here
+

--- a/server/api/repository/stock.go
+++ b/server/api/repository/stock.go
@@ -26,7 +26,7 @@ func (r *repository) GetStock(ctx context.Context, storeID, stockID string) (*mo
 	stock := &model.Stock{}
 
 	if err := r.db.Unscoped().
-		Where("stocks.store_id = ? OR stocks.id = ?", storeID, stockID).
+		Where("stocks.store_id = ? AND stocks.id = ?", storeID, stockID).
 		First(&stock).
 		Error; err != nil {
 		return nil, err

--- a/server/api/usecase/stock.go
+++ b/server/api/usecase/stock.go
@@ -2,9 +2,12 @@ package usecase
 
 import (
 	"context"
-
+	"errors" // errorsパッケージをインポート
+	"net/http" // net/httpパッケージをインポート
 	"github.com/buysell-technologies/summer-internship-2024-backend/api/domain/model"
 	"github.com/buysell-technologies/summer-internship-2024-backend/api/usecase/request"
+	"github.com/labstack/echo/v4" // echoをインポート
+	"gorm.io/gorm" // gormをインポート
 )
 
 func (u *usecase) GetStocks(ctx context.Context, input request.GetStocksRequest) ([]*model.Stock, error) {
@@ -32,6 +35,12 @@ func (u *usecase) GetStocks(ctx context.Context, input request.GetStocksRequest)
 func (u *usecase) GetStock(ctx context.Context, storeID, stockID string) (*model.Stock, error) {
 	stock, err := u.Repository.GetStock(ctx, storeID, stockID)
 	if err != nil {
+		// エラーハンドリングを追加
+		// 店舗ID,在庫IDが共に一致するレコードが見つからなかった場合のエラー
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.statusNotFound, "stock not found")
+		}
+		// その他データベース周りのエラー
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- 必要に応じて変更してください -->

## Issue の URL

https://github.com/buysell-technologies/summer-internship-2025-0909-a/issues/10

## やったこと

### 1. repository/stock.go
`Where("stocks.store_id = ? OR stocks.id = ?", storeID, stockID).`
↓
`Where("stocks.store_id = ? AND stocks.id = ?", storeID, stockID).`

### 2. usecase/stock.go
```
// 店舗ID,在庫IDが共に一致するレコードが見つからなかった場合のエラーハンドリングを追加
if errors.Is(err, gorm.ErrRecordNotFound) {
	return nil, echo.NewHTTPError(http.statusNotFound, "stock not found")
}
```


## 動作確認観点

- 在庫取得機能に関して、goot first issueのissue#2が未解決のため動作確認未実施の状態
