### PR TITLE
Fix: add Preload('stocks') to repository/user.go to fix N+1 issue in …

### DIFF
--- a/server/api/repository/user.go
+++ b/server/api/repository/user.go
@@ -11,6 +11,7 @@ func (r *repository) GetUsers(ctx context.Context, tenantID string, limit, offse
 	users := []*model.User{}
 
 	if err := r.db.Unscoped().
+		Preload("Stocks").
 		Joins("LEFT JOIN stores AS s ON users.store_id = s.id").
 		Where("s.tenant_id = ?", tenantID).
 		Limit(limit).
@@ -20,12 +21,12 @@ func (r *repository) GetUsers(ctx context.Context, tenantID string, limit, offse
 		return nil, err
 	}
 
-	for i, user := range users {
-		stocks := []*model.Stock{}
-		if err := r.db.Where("user_id = ?", user.ID).Find(&stocks).Error; err == nil {
-			users[i].Stocks = stocks
-		}
-	}
+	// for i, user := range users {
+	// 	stocks := []*model.Stock{}
+	// 	if err := r.db.Where("user_id = ?", user.ID).Find(&stocks).Error; err == nil {
+	// 		users[i].Stocks = stocks
+	// 	}
+	// }
 
 	return users, nil
 }


### PR DESCRIPTION

<!-- 必要に応じて変更してください -->

## Issue の URL



## やったこと
- N+1問題が発生していた。
 -- repository/user.goのGetUsersにおいて、`Preload("Stocks").`を追記。
 -- for文の繰り返しをコメントアウト

**修正前：**
```
func (r *repository) GetUsers(ctx context.Context, tenantID string, limit, offset int) ([]*model.User, error) {
	users := []*model.User{}

	if err := r.db.Unscoped().
		Joins("LEFT JOIN stores AS s ON users.store_id = s.id").
		Where("s.tenant_id = ?", tenantID).
		Limit(limit).
		Offset(offset).
		Find(&users).
		Error; err != nil {
		return nil, err
	}

	for i, user := range users {
 	   stocks := []*model.Stock{}
 	   if err := r.db.Where("user_id = ?", user.ID).Find(&stocks).Error; err == nil {
		users[i].Stocks = stocks
		}
	   }

	return users, nil
}
```

**修正後：**
```
func (r *repository) GetUsers(ctx context.Context, tenantID string, limit, offset int) ([]*model.User, error) {
	users := []*model.User{}

	if err := r.db.Unscoped().
		Preload("Stocks").
		Joins("LEFT JOIN stores AS s ON users.store_id = s.id").
		Where("s.tenant_id = ?", tenantID).
		Limit(limit).
		Offset(offset).
		Find(&users).
		Error; err != nil {
		return nil, err
	}

	return users, nil
}
```

## 動作確認観点
<img width="1066" height="128" alt="スクリーンショット 2025-09-09 17 08 28" src="https://github.com/user-attachments/assets/1477c960-0f4e-4c27-97ec-4921462887dd" />

<img width="739" height="590" alt="スクリーンショット 2025-09-09 17 08 59" src="https://github.com/user-attachments/assets/d37f427d-8f79-4a01-af91-66e2ebca14ee" />


- [x] ログにSQL実行文の出力を行い、実行されるSQLが減少することを確認した
